### PR TITLE
Add daily report automation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
 # codex
-测试chatgpt 的 codex
+
+这是一个简单的示例仓库，包含用于生成并发送 AI 场景日报的脚本 `daily_report.py`。
+
+## 使用方法
+1. 在仓库根目录下创建 `config.json`，配置发件人、收件人以及 SMTP 服务信息。示例配置如下：
+
+```json
+{
+  "from": "sender@example.com",
+  "to": ["receiver@example.com"],
+  "cc": ["cc@example.com"],
+  "smtp_server": "smtp.example.com",
+  "smtp_port": 25,
+  "username": "user",
+  "password": "pass"
+}
+```
+
+2. 运行脚本生成并发送日报：
+
+```bash
+python daily_report.py --date 2025-07-25 \
+  --AI质检专家 "完成模型调试" \
+  --AI+云监管 "部署上线" \
+  --进度 "按计划推进" \
+  --造价 "无" \
+  --智能问答 "" \
+  --智能问数 "数据整理" \
+  --工程文档智能生成 "" \
+  --工程文档智能审核 "初步测试"
+```
+
+脚本会根据输入自动生成日报并发送到配置文件中指定的邮箱地址，随后在控制台输出邮件发送状态以及填写了进展的场景数量。

--- a/config.json
+++ b/config.json
@@ -1,0 +1,9 @@
+{
+  "from": "sender@example.com",
+  "to": ["receiver@example.com"],
+  "cc": [],
+  "smtp_server": "smtp.example.com",
+  "smtp_port": 25,
+  "username": "user",
+  "password": "pass"
+}

--- a/daily_report.py
+++ b/daily_report.py
@@ -1,0 +1,82 @@
+import argparse
+import json
+from datetime import datetime
+import smtplib
+from email.message import EmailMessage
+from pathlib import Path
+
+SCENES = [
+    "AI质检专家",
+    "AI+云监管",
+    "进度",
+    "造价",
+    "智能问答",
+    "智能问数",
+    "工程文档智能生成",
+    "工程文档智能审核",
+]
+
+CONFIG_PATH = Path(__file__).with_name("config.json")
+
+
+def load_config():
+    if CONFIG_PATH.exists():
+        with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return {}
+
+
+def get_args():
+    parser = argparse.ArgumentParser(description="Generate and send AI scene daily report")
+    parser.add_argument("--date", help="Date in YYYY-MM-DD format", required=True)
+    for scene in SCENES:
+        parser.add_argument(f"--{scene}", dest=scene, help=f"Progress for {scene}")
+    return parser.parse_args()
+
+
+def format_report(date: datetime, progress_map):
+    weekday_map = "一二三四五六日"
+    weekday = weekday_map[date.weekday()]
+    lines = [f"# {date.year} 年 {date.month} 月 {date.day} 日(星期 {weekday})AI场景日报"]
+    for i, scene in enumerate(SCENES, start=1):
+        progress = progress_map.get(scene) or "无"
+        lines.append(f"场景 {i}：{scene}")
+        lines.append(f"场景进展：{progress}\n")
+    return "\n".join(lines)
+
+
+def send_mail(subject: str, body: str, config):
+    msg = EmailMessage()
+    msg.set_content(body)
+    msg["Subject"] = subject
+    msg["From"] = config.get("from")
+    msg["To"] = ",".join(config.get("to", []))
+    if config.get("cc"):
+        msg["Cc"] = ",".join(config.get("cc", []))
+    try:
+        with smtplib.SMTP(config.get("smtp_server", "localhost"), config.get("smtp_port", 25)) as smtp:
+            if config.get("username") and config.get("password"):
+                smtp.login(config["username"], config["password"])
+            smtp.send_message(msg)
+        return True
+    except Exception as e:
+        print(f"Failed to send email: {e}")
+        return False
+
+
+def main():
+    args = get_args()
+    date = datetime.strptime(args.date, "%Y-%m-%d")
+    progress_map = {scene: getattr(args, scene) for scene in SCENES}
+    report = format_report(date, progress_map)
+    config = load_config()
+    weekday_map = "一二三四五六日"
+    subject = f"{date.year} 年 {date.month} 月 {date.day} 日(星期 {weekday_map[date.weekday()]})AI 应用场景日报"
+    status = send_mail(subject, report, config)
+    filled_count = sum(1 for p in progress_map.values() if p)
+    print("邮件发送成功" if status else "邮件发送失败")
+    print(f"已填写工作日报的场景数: {filled_count}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a script `daily_report.py` that compiles progress for eight AI scenes and sends an email
- provide example `config.json`
- update README with usage instructions

## Testing
- `python daily_report.py --help`
- `python daily_report.py --date 2025-07-25 --AI质检专家 测试进展` *(fails: Name or service not known)*

------
https://chatgpt.com/codex/tasks/task_e_6884bdd5ef1c832fa3552adc34df7305